### PR TITLE
Implemented ecma6 class support for component dependencies

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -344,6 +344,15 @@ function extractVariableDeps(varName, scope) {
     params = _.get(varNode, 'init.params', []);
   }
 
+  // covers "class SomeClass ...";
+  if (varType === 'ClassDeclaration') {
+    var methods = _.get(varNode, 'body.body', []);
+    var constructor = methods.find((item) => {
+      return item.kind === "constructor"
+    });
+    params = _.get(constructor, 'value.params', []);
+  }
+
   var deps = extractDeps(params);
 
   return deps;

--- a/test/specs/parse/deps.spec.js
+++ b/test/specs/parse/deps.spec.js
@@ -267,4 +267,25 @@ describe('parse/deps', function () {
     "angular.module('test', []) .component('TestComponent', TestComponent);";
   });
 
+  it('should extract deps for component and controller as ecma6 class declaration',
+      function () {
+        var source =
+            "class TestController {" +
+            "constructor ($scope) {}}" +
+            "angular" +
+            " .module('test', [])" +
+            " .component('TestComponent', {" +
+            "   controller: TestController" +
+            " });";
+
+        var units = parse(source);
+
+        assert.deepEqual(units, [{
+          type: 'component',
+          name: 'TestComponent',
+          module: { name: 'test' },
+          deps: [{ name: '$scope' }]
+        }]);
+      });
+
 });


### PR DESCRIPTION
Covered functionality when compoennt controller uses as class:

class SomeController {
constructor(service1, service2...) {
}
}
angular.module('mymodule').component('myComponent', {
        templateUrl: "my-component.html",
        controller: SomeController
    });